### PR TITLE
docs: add skill cards for the eight kermt-* agent skills

### DIFF
--- a/agent/skills/kermt-add-cmim-pretrain/skill-card.md
+++ b/agent/skills/kermt-add-cmim-pretrain/skill-card.md
@@ -1,0 +1,77 @@
+## Description: <br>
+Converts a grover_base checkpoint into a hybrid checkpoint by adding a randomly-initialized cMIM decoder and latent distribution, then continues pretraining on the user's corpus in hybrid (vocab + contrast) mode. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML research engineers who want the cMIM contrastive objective on top of an existing grover_base KERMT checkpoint without retraining from scratch. Functionally `kermt-continue-pretrain` with a one-time checkpoint-conversion step prepended. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): API key — `WANDB_API_KEY` for optional Weights & Biases run tracking <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU (multi-GPU supported via DDP) <br>
+* A grover_base checkpoint (encoder-only, or encoder + vocab heads) <br>
+* A pretraining corpus CSV <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The newly added cMIM decoder and latent distribution are randomly initialized, so the converted checkpoint performs worse than its source until sufficient hybrid pretraining has run — a checkpoint taken too early is silently degraded. <br>
+Mitigation: The conversion step is explicitly separated from the training step, and `kermt-monitor` exposes validation loss so users can confirm convergence before adopting the result. <br>
+
+Risk: Continued pretraining is a long-running, multi-GPU workload that a single agent instruction can start, potentially consuming days of GPU time. <br>
+Mitigation: Runs launch detached with a run manifest; `kermt-monitor` provides progress visibility and the container identifiers needed to terminate early. <br>
+
+Risk: Supplying a checkpoint that is not grover_base (e.g. already cmim or hybrid) would produce an invalid conversion. <br>
+Mitigation: The skill validates the source checkpoint type before conversion. <br>
+
+Risk: Conversion and data preparation write new checkpoint and shard/vocab/feature artifacts that can overwrite prior output. <br>
+Mitigation: Artifacts are written under an explicit run/output path; the source checkpoint is not modified in place. <br>
+
+Risk: When Weights & Biases tracking is enabled, run metadata is transmitted to a third-party service. <br>
+Mitigation: W&B tracking is optional and off unless the user supplies `WANDB_API_KEY`. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/scripts/run_pretrain_local.py` — extended usage examples <br>
+- Related skills: `kermt-setup`, `kermt-monitor`, `kermt-continue-pretrain`, `kermt-pretrain-scratch` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Converted hybrid checkpoint; subsequent training checkpoints; shard/vocab/feature artifacts; training logs; `run.json` manifest; Markdown launch summary] <br>
+**Output Parameters:** [1D — run identifier, container id, converted checkpoint path, output paths] <br>
+**Other Properties Related to Output:** [Detached execution: the skill returns after launch, not after training completes.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering source-checkpoint validation, cMIM conversion, corpus preparation, and detached launch. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Models produced by this skill inherit the composition and biases of the user's pretraining corpus. Downstream predictions are research hypotheses and must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/agent/skills/kermt-continue-pretrain/skill-card.md
+++ b/agent/skills/kermt-continue-pretrain/skill-card.md
@@ -1,0 +1,77 @@
+## Description: <br>
+Continues pretraining from an existing KERMT checkpoint — validating the checkpoint and corpus, preparing shard/vocab/feature artifacts, and launching `pretrain_ddp.py` inside the KERMT container with `--pretrain_mode` auto-dispatched from the checkpoint type. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML engineers adapting a KERMT foundation model to a domain-specific molecular corpus — for example an in-house compound collection — before task finetuning, without discarding the representations already learned. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): API key — `WANDB_API_KEY` for optional Weights & Biases run tracking <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU (multi-GPU supported via DDP) <br>
+* An existing KERMT checkpoint (grover_base vocab-only, cmim, or hybrid) <br>
+* A pretraining corpus CSV <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Continued pretraining is a long-running, multi-GPU workload that a single agent instruction can start, potentially consuming days of GPU time and substantial cloud spend. <br>
+Mitigation: Runs launch detached with a run manifest; `kermt-monitor` provides progress visibility and the container identifiers needed to terminate early. <br>
+
+Risk: Selecting the wrong `--pretrain_mode` for a checkpoint would train against the wrong objective and silently waste the entire run. <br>
+Mitigation: The skill auto-dispatches `--pretrain_mode` from the detected checkpoint type rather than relying on the user to specify it. <br>
+
+Risk: Data preparation writes shard, vocabulary, and feature artifacts that can be large and can overwrite prior preparation output. <br>
+Mitigation: Preparation writes under an explicit run/output path supplied by the user. <br>
+
+Risk: Continued pretraining on a narrow corpus can degrade general-purpose representations (catastrophic forgetting) in ways not visible until downstream finetuning. <br>
+Mitigation: The original checkpoint is not modified in place; users should retain it and compare downstream task performance before adopting the continued-pretrain checkpoint. <br>
+
+Risk: When Weights & Biases tracking is enabled, run metadata is transmitted to a third-party service. <br>
+Mitigation: W&B tracking is optional and off unless the user supplies `WANDB_API_KEY`. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/scripts/run_pretrain_local.py` — extended usage examples <br>
+- Related skills: `kermt-setup`, `kermt-monitor`, `kermt-pretrain-scratch`, `kermt-add-cmim-pretrain`, `kermt-finetune` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Model checkpoint files; shard/vocab/feature artifacts; training logs; `run.json` manifest; Markdown launch summary] <br>
+**Output Parameters:** [1D — run identifier, container id, resolved pretrain mode, output paths] <br>
+**Other Properties Related to Output:** [Detached execution: the skill returns after launch, not after training completes.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+5 evaluation tasks defined in `evals/evals.json`, covering checkpoint validation, corpus validation, data preparation, pretrain-mode dispatch, and detached launch. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Models produced by this skill inherit the composition and biases of the user's pretraining corpus. Downstream predictions are research hypotheses and must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/agent/skills/kermt-embed/skill-card.md
+++ b/agent/skills/kermt-embed/skill-card.md
@@ -1,0 +1,69 @@
+## Description: <br>
+Extracts per-molecule embeddings from any encoder-bearing KERMT checkpoint (grover_base / cmim / hybrid / finetuned), writing one `.npy` per readout type plus `canonical_smiles.npy` and `validity.npy`. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML engineers and cheminformaticians who need fixed-length molecular representations from a KERMT encoder to feed a downstream model, clustering step, or similarity search, without training a task head. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU <br>
+* Any encoder-bearing KERMT checkpoint <br>
+* A SMILES input CSV (featurization happens on the fly — no precomputed features required) <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Embeddings from different checkpoints or readout types are not comparable, and mixing them in a downstream model produces silently meaningless results. <br>
+Mitigation: The skill writes each readout type to a separately named `.npy` and emits `canonical_smiles.npy` alongside, so provenance and row alignment are explicit. <br>
+
+Risk: Invalid SMILES rows would misalign embeddings against the caller's original input ordering. <br>
+Mitigation: The skill emits `validity.npy`, letting the caller filter or realign rows deterministically. <br>
+
+Risk: Large input libraries can produce embedding arrays of substantial size and consume significant disk. <br>
+Mitigation: Outputs are written to a user-specified directory; users should size storage for the molecule count and embedding dimensionality before running. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `task/extract_embeddings.py` — the underlying extraction entry point <br>
+- Related skills: `kermt-setup`, `kermt-finetune`, `kermt-infer` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files] <br>
+**Output Format:** [NumPy `.npy` arrays — one per readout type (atom_from_atom, bond_from_atom, atom_from_bond, bond_from_bond), plus `canonical_smiles.npy` and `validity.npy`] <br>
+**Output Parameters:** [2D — one row per input molecule, one column per embedding dimension] <br>
+**Other Properties Related to Output:** [Row order corresponds to the input CSV; `validity.npy` identifies rows whose SMILES failed to parse] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+5 evaluation tasks defined in `evals/evals.json`, covering checkpoint compatibility, readout selection, and output artifact production. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/agent/skills/kermt-finetune/skill-card.md
+++ b/agent/skills/kermt-finetune/skill-card.md
@@ -1,0 +1,78 @@
+## Description: <br>
+Finetunes a pretrained KERMT encoder on a labeled CSV — validating the input checkpoint and dataset, preparing features and optional splits, then launching `main.py finetune` inside the KERMT container as a detached, hours-scale run. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Computational chemists and ML engineers adapting a pretrained KERMT encoder (grover_base / cmim / hybrid) to their own labeled molecular property dataset — for example an in-house ADMET assay panel — before running predictions with `kermt-infer`. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): API key — `WANDB_API_KEY` for optional Weights & Biases run tracking <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU <br>
+* A pretrain checkpoint (grover_base, cmim, or hybrid) <br>
+* A labeled CSV with SMILES and one or more target columns <br>
+* Hyperparameters default from `agent/config/defaults_finetune.json`, overridable per flag <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Finetuning is an hours-scale GPU workload that a single agent instruction can start, consuming substantial GPU-hours or cloud spend. <br>
+Mitigation: Runs launch detached with a run manifest, and `kermt-monitor` gives the user continuous visibility and the container identifiers needed to terminate early. <br>
+
+Risk: Supplying a finetuned checkpoint instead of a pretrain checkpoint would produce an invalid training configuration. <br>
+Mitigation: The skill validates the checkpoint type before launching and rejects non-pretrain checkpoints. <br>
+
+Risk: A poorly split dataset (e.g. random splits on congeneric series) yields optimistic validation metrics that do not generalize. <br>
+Mitigation: The skill exposes explicit split handling rather than defaulting silently; users remain responsible for choosing a split strategy appropriate to their chemistry. <br>
+
+Risk: Training writes checkpoints and logs into a user-specified directory and can overwrite artifacts from a previous run. <br>
+Mitigation: Outputs are written under an explicit run directory; users should use distinct output paths per experiment. <br>
+
+Risk: When Weights & Biases tracking is enabled, run metadata is transmitted to a third-party service. <br>
+Mitigation: W&B tracking is optional and off unless the user supplies `WANDB_API_KEY`; users should confirm their data-handling policy before enabling it. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/config/defaults_finetune.json` — default hyperparameters <br>
+- Related skills: `kermt-setup`, `kermt-monitor`, `kermt-infer`, `kermt-embed` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Model checkpoint files; training logs; `run.json` manifest; Markdown launch summary] <br>
+**Output Parameters:** [1D — run identifier, container id, configured hyperparameters, output paths] <br>
+**Other Properties Related to Output:** [Detached execution: the skill returns after launch, not after training completes. Use `kermt-monitor` for progress.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+5 evaluation tasks defined in `evals/evals.json`, covering checkpoint validation, dataset validation, data preparation, and detached launch. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Models finetuned with this skill inherit the biases and coverage limits of the user's training data. Resulting predictions are research hypotheses and must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/agent/skills/kermt-infer/skill-card.md
+++ b/agent/skills/kermt-infer/skill-card.md
@@ -47,7 +47,7 @@ Mitigation: Outputs are written under an explicit output path supplied by the us
 ## Skill Output: <br>
 **Output Type(s):** [Analysis, Files] <br>
 **Output Format:** [CSV of per-molecule predictions; Markdown summary] <br>
-**Output Parameters:** [2D — one row per input molecule, one column per predicted task] <br>
+**Output Parameters:** [2D — one row per valid input molecule after cleaning and canonicalization, one column per predicted task] <br>
 **Other Properties Related to Output:** [Predictions are model estimates, not measurements, and are not calibrated probabilities of experimental outcome. Runs blocking, on a minutes-scale timeframe.] <br>
 
 ## Evaluation Agents Used: <br>

--- a/agent/skills/kermt-infer/skill-card.md
+++ b/agent/skills/kermt-infer/skill-card.md
@@ -1,0 +1,74 @@
+## Description: <br>
+Runs molecular property predictions with a finetuned KERMT checkpoint on a SMILES-only CSV, validating that the checkpoint carries task FFN heads, preparing rdkit_2d features, and launching `main.py predict` inside the KERMT container. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Computational chemists and drug-discovery teams scoring a library of candidate molecules for ADMET or other molecular properties using a KERMT model they have already finetuned. Not for use with pretrain checkpoints — the skill refuses those and redirects to `kermt-finetune`. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU <br>
+* A finetuned KERMT checkpoint containing task FFN heads <br>
+* A SMILES-only input CSV <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: Predictions are computational estimates and may be applied outside the chemical space the model was finetuned on, producing confidently wrong property values for novel scaffolds. <br>
+Mitigation: Users must treat outputs as hypotheses requiring experimental validation, and should check that input chemistry resembles the finetuning set before acting on predictions. <br>
+
+Risk: Supplying a pretrain checkpoint instead of a finetuned one would yield meaningless outputs. <br>
+Mitigation: The skill validates the checkpoint for task FFN heads before running and refuses pretrain checkpoints with an explicit redirect to `kermt-finetune`. <br>
+
+Risk: Malformed or non-parseable SMILES silently reduce the effective prediction set. <br>
+Mitigation: The skill runs a data-preparation and cleaning step that reports invalid rows before inference. <br>
+
+Risk: The skill writes prediction outputs into a user-specified directory and can overwrite prior results. <br>
+Mitigation: Outputs are written under an explicit output path supplied by the user; no files outside that path are modified. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- [RDKit documentation](https://www.rdkit.org/docs/) — `rdkit_2d` descriptor featurization <br>
+- Related skills: `kermt-finetune` (produces the required checkpoint), `kermt-embed` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis, Files] <br>
+**Output Format:** [CSV of per-molecule predictions; Markdown summary] <br>
+**Output Parameters:** [2D — one row per input molecule, one column per predicted task] <br>
+**Other Properties Related to Output:** [Predictions are model estimates, not measurements, and are not calibrated probabilities of experimental outcome. Runs blocking, on a minutes-scale timeframe.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering checkpoint validation, CSV validation, feature preparation, and the predict invocation. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Molecular property predictions produced by this skill are computational hypotheses for research and development workflows. They must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/agent/skills/kermt-monitor/skill-card.md
+++ b/agent/skills/kermt-monitor/skill-card.md
@@ -29,7 +29,7 @@ Global <br>
 
 ## Known Risks and Mitigations: <br>
 Risk: A stale or missing `run.json` can cause the skill to report on the wrong run, or to report nothing while a job is in fact still consuming GPU-hours. <br>
-Mitigation: The skill cross-checks `run.json` against live Docker container state rather than trusting the manifest alone. <br>
+Mitigation: The skill refuses to proceed when `run.json` is missing, and reports container identifiers so the user can verify the run directly. Because `run.json` does not record a container name, pass `--container <name-or-id>` when monitoring a specific run. <br>
 
 Risk: Log tailing surfaces run output into the agent transcript, which may include file paths or environment details. <br>
 Mitigation: The skill reads only the pretrain/finetune log; users should treat agent transcripts as sensitive and avoid pasting credentials into run configuration. <br>

--- a/agent/skills/kermt-monitor/skill-card.md
+++ b/agent/skills/kermt-monitor/skill-card.md
@@ -1,0 +1,70 @@
+## Description: <br>
+Reports progress for a detached KERMT run by reading `run.json`, querying Docker for container state, tailing the pretrain/finetune log, and parsing progress lines (epoch, step, validation loss). <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML engineers running long KERMT pretraining or finetuning jobs who need to check status, spot divergence early, and decide whether to let a run continue or terminate it. This is the companion skill to every detached `kermt-*` training invocation. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* Docker <br>
+* `jq` <br>
+* A prior detached KERMT run that produced a `run.json` <br>
+
+Note: unlike the training skills, this skill does not require a GPU. <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: A stale or missing `run.json` can cause the skill to report on the wrong run, or to report nothing while a job is in fact still consuming GPU-hours. <br>
+Mitigation: The skill cross-checks `run.json` against live Docker container state rather than trusting the manifest alone. <br>
+
+Risk: Log tailing surfaces run output into the agent transcript, which may include file paths or environment details. <br>
+Mitigation: The skill reads only the pretrain/finetune log; users should treat agent transcripts as sensitive and avoid pasting credentials into run configuration. <br>
+
+Risk: This skill is read-only and cannot stop a runaway job, so a user may assume monitoring implies control. <br>
+Mitigation: The skill reports container identifiers so the user can terminate the run directly via Docker if needed. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/scripts/kermt_container.sh` — defines `kermt_run_detached`, the wrapper whose runs this skill observes <br>
+- Related skills: `kermt-pretrain-scratch`, `kermt-continue-pretrain`, `kermt-finetune` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis] <br>
+**Output Format:** [Markdown status report] <br>
+**Output Parameters:** [1D — container state, current epoch, current step, latest validation loss] <br>
+**Other Properties Related to Output:** [Read-only; the skill makes no changes to the run or the host] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering run discovery, container-state reporting, and log progress parsing. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/agent/skills/kermt-pretrain-scratch/skill-card.md
+++ b/agent/skills/kermt-pretrain-scratch/skill-card.md
@@ -1,0 +1,77 @@
+## Description: <br>
+Pretrains a fresh KERMT model from scratch on a user-provided corpus — building a new vocabulary, instantiating the model architecture from defaults, and launching `pretrain_ddp.py` inside the KERMT container with no starting checkpoint loaded. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+ML research engineers training a KERMT model from random initialization on a corpus sufficiently large and distinct that continued pretraining from an existing checkpoint is not appropriate. For most users, `kermt-continue-pretrain` is the better starting point. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: Optional <br>
+Credential Type(s): API key — `WANDB_API_KEY` for optional Weights & Biases run tracking <br>
+
+* `kermt-setup` completed (supplies the `kermt:latest` image) <br>
+* Docker, NVIDIA Container Toolkit, CUDA-capable NVIDIA GPU (multi-GPU strongly recommended; DDP supported) <br>
+* A large pretraining corpus CSV <br>
+* Substantial disk for shard, vocabulary, and feature artifacts <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: This is the most expensive skill in the KERMT family — training from random initialization can consume days to weeks of multi-GPU time, and a single agent instruction can start it. <br>
+Mitigation: Runs launch detached with a run manifest; `kermt-monitor` provides progress visibility and the container identifiers needed to terminate early. Users should confirm corpus scale justifies from-scratch training before invoking. <br>
+
+Risk: Training from scratch on an insufficiently large corpus produces a model materially worse than the available pretrained checkpoints, with the cost discovered only after the run. <br>
+Mitigation: The skill is documented as the exception path, with `kermt-continue-pretrain` as the recommended default; users should benchmark against an existing checkpoint before committing. <br>
+
+Risk: A vocabulary built from the user's corpus is not interchangeable with vocabularies from other checkpoints, so resulting models are incompatible with checkpoints trained elsewhere. <br>
+Mitigation: The new vocabulary is written alongside the checkpoint in the run directory, making the pairing explicit and auditable. <br>
+
+Risk: Data preparation writes large shard/vocab/feature artifacts and can overwrite prior preparation output. <br>
+Mitigation: Preparation writes under an explicit run/output path supplied by the user. <br>
+
+Risk: When Weights & Biases tracking is enabled, run metadata is transmitted to a third-party service. <br>
+Mitigation: W&B tracking is optional and off unless the user supplies `WANDB_API_KEY`. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- `agent/scripts/run_pretrain_local.py` — extended usage examples <br>
+- Related skills: `kermt-setup`, `kermt-monitor`, `kermt-continue-pretrain`, `kermt-finetune` <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Files, Analysis] <br>
+**Output Format:** [Model checkpoint files; new vocabulary; shard/feature artifacts; training logs; `run.json` manifest; Markdown launch summary] <br>
+**Output Parameters:** [1D — run identifier, container id, vocabulary path, model configuration, output paths] <br>
+**Other Properties Related to Output:** [Detached execution: the skill returns after launch, not after training completes.] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering corpus validation, vocabulary construction, architecture instantiation, and detached launch. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+Models produced by this skill inherit the composition and biases of the user's pretraining corpus entirely, with no counterbalancing from prior pretraining. Downstream predictions are research hypotheses and must not be used as the sole basis for clinical, safety, or regulatory decisions. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>

--- a/agent/skills/kermt-setup/skill-card.md
+++ b/agent/skills/kermt-setup/skill-card.md
@@ -1,0 +1,69 @@
+## Description: <br>
+Bootstraps the KERMT agent environment — verifies host Docker and the NVIDIA Container Toolkit, builds the `kermt:latest` image from the repository Dockerfile if absent, and runs a GPU smoke test inside the container. <br>
+
+This skill is ready for commercial/non-commercial use. <br>
+
+## Owner
+NVIDIA (evax@nvidia.com) <br>
+
+### License/Terms of Use: <br>
+Apache-2.0 <br>
+
+## Use Case: <br>
+Computational chemists and ML engineers preparing a workstation or GPU node to run any `kermt-*` skill. Every other KERMT skill depends on this one; it is the first skill to invoke on a fresh clone. <br>
+
+### Requirements/Dependencies: <br>
+Requires API Key or External Credential: No <br>
+Credential Type(s): None <br>
+
+* Docker <br>
+* NVIDIA Container Toolkit <br>
+* CUDA-capable NVIDIA GPU <br>
+* A local clone of the KERMT repository (supplies the Dockerfile) <br>
+
+Do not include secrets in prompts/logs/output; use least-privilege credentials; rotate keys as appropriate. <br>
+
+### Deployment Geography for Use: <br>
+Global <br>
+
+## Known Risks and Mitigations: <br>
+Risk: The skill builds a container image and runs GPU workloads, which consumes significant local disk and can take tens of minutes on a cold cache. <br>
+Mitigation: The skill checks for an existing `kermt:latest` image and skips the build when one is present; the smoke test is short and read-only. <br>
+
+Risk: Docker commands require elevated host privileges, and an agent running them has broad access to the host container runtime. <br>
+Mitigation: The skill issues only build, run, and inspect commands against the KERMT image; users should keep their agent's command-approval gate enabled and review commands before execution. <br>
+
+Risk: A partially configured host (driver/toolkit mismatch) can produce a container that starts but cannot see the GPU, causing confusing downstream failures in training skills. <br>
+Mitigation: The GPU smoke test runs inside the container and fails loudly at setup time rather than deferring the error to a long-running job. <br>
+
+## Reference(s): <br>
+- [KERMT repository](https://github.com/NVIDIA-BioNeMo/KERMT) <br>
+- [NVIDIA Container Toolkit documentation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/) <br>
+- `agent/scripts/kermt_container.sh` — container entry points used by this skill <br>
+
+## Skill Output: <br>
+**Output Type(s):** [Analysis, Configuration instructions] <br>
+**Output Format:** [Markdown status report with inline bash commands] <br>
+**Output Parameters:** [1D — pass/fail status per environment check] <br>
+**Other Properties Related to Output:** [Side effect: builds the `kermt:latest` Docker image on the host if it does not already exist] <br>
+
+## Evaluation Agents Used: <br>
+Target agents: `claude-code`, `codex`. NVSkills-Eval has not yet been run against this skill — see Evaluation Results. <br>
+
+## Evaluation Tasks: <br>
+4 evaluation tasks defined in `evals/evals.json`, covering environment verification, image build, and GPU smoke test paths. <br>
+
+## Evaluation Metrics Used: <br>
+Planned NVSkills-Eval dimensions: Security, Correctness, Discoverability, Effectiveness, Efficiency. <br>
+
+## Evaluation Results: <br>
+Pending. NVSkills-Eval has not been run for this skill; results and a `BENCHMARK.md` will be published when the evaluation pipeline runs. <br>
+
+## Skill Version(s): <br>
+b1c082c (source: git SHA, committed 2026-07-17) <br>
+
+## Ethical Considerations: <br>
+NVIDIA believes Trustworthy AI is a shared responsibility and we have established policies and practices to enable development for a wide array of AI applications. When downloaded or used in accordance with our terms of service, developers should work with their internal team to ensure this skill meets requirements for the relevant industry and use case and addresses unforeseen product misuse. <br>
+
+(For Release on NVIDIA Platforms Only) <br>
+Please report quality, risk, security vulnerabilities or NVIDIA AI Concerns [here](https://www.nvidia.com/en-us/support/submit-security-vulnerability/). <br>


### PR DESCRIPTION
Adds a `skill-card.md` alongside each of the eight `kermt-*` skills, following the NVIDIA skill card format used across the [NVIDIA/skills](https://github.com/NVIDIA/skills) catalog (326/326 skills there carry one).

## Why

The NVIDIA/skills sync workflow **drops any skill missing `skill-card.md`, `skill.oms.sig`, or an eval dataset** — the enforcement step removes the skill dir before the PR is created, so non-compliant skills never merge into the catalog. The same requirement is tracked as `SRC-11` in `bionemo-agent-toolkit`'s CONTRIBUTING.

State of this repo against those three artifacts:

| Artifact | Status |
|---|---|
| eval dataset | present — 4–5 tasks per skill under `evals/` |
| `skill-card.md` | **this PR** |
| `skill.oms.sig` | outstanding — needs `nvskills-ci` wired here (see below) |

## What's in the cards

Per skill: description, owner, license, use case, requirements/dependencies (Docker, NVIDIA Container Toolkit, GPU, optional `WANDB_API_KEY`), risks and mitigations, references, output types, evaluation, and ethical considerations.

Risk sections are specific rather than generic — GPU-hour cost on the detached training skills, catastrophic forgetting on `kermt-continue-pretrain`, the randomly-initialized decoder on `kermt-add-cmim-pretrain`, checkpoint-type validation on `kermt-infer`, and third-party data transmission when W&B tracking is enabled.

**Evaluation results are marked pending, not fabricated.** NVSkills-Eval has not been run against these skills; the cards state the eval task counts that exist and say results and a `BENCHMARK.md` will follow.

## Still needed after this: signatures

`skill.oms.sig` cannot be added by a PR — it is emitted by the `NVIDIA/nvskills-ci` service. Wiring it here needs:

1. a `request-nvskills-ci.yml` workflow (this repo currently has no `.github/workflows/` at all),
2. the `NVSKILLS_CI_DISPATCH_TOKEN` secret,
3. a maintainer commenting `/nvskills-ci` on a PR.

Happy to open that as a follow-up if it's wanted here.

## Context

`bionemo-agent-toolkit` vendors these eight skills via `components.d/kermt.yml` and rsyncs with `--delete`, so a card committed there is wiped on the next nightly sync. This repo is the source of truth. The catalog carries an interim copy of these same cards in a `compliance.d/` overlay, which is retired automatically once this merges.

Please correct anything I got wrong about the skills' behavior or risks — I wrote these from the SKILL.md files and repo layout, not from running the pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
